### PR TITLE
Introduce a CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
             - run: nix build .#sitl_bc
             - uses: actions/upload-artifact@v4
               with:
+                if-no-files-found: error
                 path: result/bc/bin
                 name: supervolo-sitl-bitcode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: cachix/cachix-action@v15
               with:
                 name: galois
-		authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+                authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
             - run: nix build .#sitl_bc
             - uses: actions/upload-artifact@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
     sitl-bc:
         runs-on: ubuntu-24.04
+        strategy:
+          matrix:
+            nix_target: ['sitl_bc', 'ardupilot_sitl_bc']
         steps:
             - uses: actions/checkout@v4
             - uses: cachix/install-nix-action@v31
@@ -16,9 +19,9 @@ jobs:
               with:
                 name: galois
                 authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-            - run: nix build .#sitl_bc
+            - run: nix build .#${{ matrix.nix_target }}
             - uses: actions/upload-artifact@v4
               with:
                 if-no-files-found: error
                 path: result/bc/bin
-                name: supervolo-sitl-bitcode
+                name: ${{ matrix.nix_target }}-bitcode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
             - uses: cachix/cachix-action@v15
               with:
                 name: galois
+		authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
             - run: nix build .#sitl_bc
             - uses: actions/upload-artifact@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: flake-supervolo
+on:
+  push:
+    branches: [main, ci-test]
+  pull_request:
+
+jobs:
+    sitl-bc:
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@v4
+            - uses: cachix/install-nix-action@v31
+              with:
+                github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            - uses: cachix/cachix-action@v15
+              with:
+                name: galois
+            - run: nix build .#sitl_bc
+            - uses: actions/upload-artifact@v4
+              with:
+                path: result/bc/bin
+                name: supervolo-sitl-bitcode


### PR DESCRIPTION
This adds a CI workflow to run the `sitl_bc` build and output the resulting bitcode as an artifact.

It uses the Galois Cachix key for read/write access to the cache; I am unsure if this has to be set up explicitly or is available across the entire organization. 